### PR TITLE
Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,46 @@ Flagship.define :blog do
 end
 ```
 
+## Helper methods
+
+You can define helpers with the `helper` keyword. Helpers can be used within blocks, procs, or as symbolic names for if statements to tidy up your code.
+
+```rb
+Flagship.define :blog do
+  helper :is_author do |comment, user|
+    comment.author == user
+  end
+
+  def can_view_comment(context)
+    context.current_user.moderator?
+  end
+
+  enable :comment, if: :can_view_comment
+  enable :comment_deletion, if: ->(context) { is_author(context.comment, context.current_user) }
+end
+```
+
+To share helpers, you can simply include them as modules.
+
+
+```rb
+module FlagHelpers
+  def is_author(context)
+    context.comment.author == context.current_user
+  end
+end
+
+Flagship.define :development do
+  include FlagHelpers
+  enable :delete, if: :is_author
+end
+
+Flagship.define :production do
+  include FlagHelpers
+  enable :delete, if: :is_author
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ end
 
 ## Helper methods
 
-You can define helpers with the `helper` keyword. Helpers can be used within blocks, procs, or as symbolic names for if statements to tidy up your code.
+You can define helpers as normal methods with `def`. Methods can be used within blocks, procs, or as symbolic names for if statements to tidy up your code.
 
 ```rb
 Flagship.define :blog do
-  helper :is_author do |comment, user|
+  def is_author(comment, user)
     comment.author == user
   end
 

--- a/lib/flagship.rb
+++ b/lib/flagship.rb
@@ -9,46 +9,48 @@ require "flagship/flagsets_container"
 module Flagship
   class NoFlagsetSelectedError < ::StandardError; end
 
-  def self.define(key, options = {}, &block)
-    context = self.default_context
-    base = options[:extend] ? self.get_flagset(options[:extend]) : nil
-    self.default_flagsets_container.add ::Flagship::Dsl.new(key, context, base, &block).flagset
-  end
+  class << self
+    def define(key, options = {}, &block)
+      context = self.default_context
+      base = options[:extend] ? self.get_flagset(options[:extend]) : nil
+      default_flagsets_container.add ::Flagship::Dsl.new(key, context, base, &block).flagset
+    end
 
-  def self.enabled?(key)
-    self.current_flagset.enabled?(key)
-  end
+    def enabled?(key)
+      current_flagset.enabled?(key)
+    end
 
-  def self.set_context(key, value)
-    self.default_context.__set(key, value)
-  end
+    def set_context(key, value)
+      default_context.__set(key, value)
+    end
 
-  def self.select_flagset(key)
-    @@current_flagset = self.default_flagsets_container.get(key)
-  end
+    def select_flagset(key)
+      @@current_flagset = default_flagsets_container.get(key)
+    end
 
-  def self.features
-    self.current_flagset.features
-  end
+    def features
+      current_flagset.features
+    end
 
-  def self.get_flagset(key)
-    self.default_flagsets_container.get(key)
-  end
+    def get_flagset(key)
+      default_flagsets_container.get(key)
+    end
 
-  def self.default_flagsets_container
-    @@default_flagsts_container ||= ::Flagship::FlagsetsContainer.new
-  end
+    def default_flagsets_container
+      @@default_flagsts_container ||= ::Flagship::FlagsetsContainer.new
+    end
 
-  def self.current_flagset
-    @@current_flagset or raise NoFlagsetSelectedError.new('No flagset is selected')
-  end
+    def current_flagset
+      @@current_flagset or raise NoFlagsetSelectedError.new('No flagset is selected')
+    end
 
-  def self.default_context
-    @@default_context ||= ::Flagship::Context.new
-  end
+    def default_context
+      @@default_context ||= ::Flagship::Context.new
+    end
 
-  def self.clear_state
-    @@default_flagsts_container = nil
-    @@current_flagset = nil
+    def clear_state
+      @@default_flagsts_container = nil
+      @@current_flagset = nil
+    end
   end
 end

--- a/lib/flagship.rb
+++ b/lib/flagship.rb
@@ -25,7 +25,7 @@ module Flagship
     end
 
     def select_flagset(key)
-      @@current_flagset = default_flagsets_container.get(key)
+      @current_flagset = default_flagsets_container.get(key)
     end
 
     def features
@@ -37,20 +37,20 @@ module Flagship
     end
 
     def default_flagsets_container
-      @@default_flagsts_container ||= ::Flagship::FlagsetsContainer.new
+      @default_flagsts_container ||= ::Flagship::FlagsetsContainer.new
     end
 
     def current_flagset
-      @@current_flagset or raise NoFlagsetSelectedError.new('No flagset is selected')
+      @current_flagset or raise NoFlagsetSelectedError.new('No flagset is selected')
     end
 
     def default_context
-      @@default_context ||= ::Flagship::Context.new
+      @default_context ||= ::Flagship::Context.new
     end
 
     def clear_state
-      @@default_flagsts_container = nil
-      @@current_flagset = nil
+      @default_flagsts_container = nil
+      @current_flagset = nil
     end
   end
 end

--- a/lib/flagship/dsl.rb
+++ b/lib/flagship/dsl.rb
@@ -51,10 +51,6 @@ class Flagship::Dsl
     @flagset.disabled?(key)
   end
 
-  def helper(name, &block)
-    define_singleton_method name, &block
-  end
-
   def include(mod)
     extend mod
   end

--- a/lib/flagship/dsl.rb
+++ b/lib/flagship/dsl.rb
@@ -19,6 +19,7 @@ class Flagship::Dsl
   def enable(key, opts = {})
     tags = opts.dup
     condition = tags.delete(:if)
+    condition = method(condition) if condition.is_a?(Symbol) # convert to proc
 
     if condition
       @features[key] = ::Flagship::Feature.new(key, condition, @context, @base_tags.merge(tags))
@@ -48,5 +49,13 @@ class Flagship::Dsl
 
   def disabled?(key)
     @flagset.disabled?(key)
+  end
+
+  def helper(name, &block)
+    define_singleton_method name, &block
+  end
+
+  def include(mod)
+    extend mod
   end
 end

--- a/spec/flagship_spec.rb
+++ b/spec/flagship_spec.rb
@@ -217,12 +217,12 @@ RSpec.describe Flagship do
       end
     end
 
-    context 'helper' do
+    context 'helper methods' do
       let(:flagset) { Flagship.default_flagsets_container.get(:foo) }
 
-      it 'provides a method you can use within procs' do
+      it 'can be used within procs' do
         Flagship.define :foo do
-          helper :is_eq do |x, y|
+          def is_eq(x, y)
             x == y
           end
 
@@ -234,10 +234,15 @@ RSpec.describe Flagship do
         expect(flagset.enabled?(:baz)).to be false
       end
 
-      it 'provides a method you can use for ifs' do
+      it 'can be symbolically referenced' do
         Flagship.define :foo do
-          helper(:is_true)  { |context| true }
-          helper(:is_false) { |context| false }
+          def is_true(context)
+            true
+          end
+
+          def is_false(context)
+            false
+          end
 
           enable :qux, if: :is_true
           enable :quz, if: :is_false
@@ -247,9 +252,12 @@ RSpec.describe Flagship do
         expect(flagset.enabled?(:quz)).to be false
       end
 
-      it 'is not shared with other flagship declarations' do
+      it 'are not shared with other flagship declarations' do
         Flagship.define :foo do
-          helper(:is_true) { |context| true }
+          def is_true(context)
+            true
+          end
+
           enable :baz, if: :is_true
         end
 
@@ -260,7 +268,7 @@ RSpec.describe Flagship do
         }.to raise_error(NameError)
       end
 
-      it 'can be defined and included in modules' do
+      it 'can be defined and included from modules' do
         module FooMethods
           def is_foo(context)
             true

--- a/spec/flagship_spec.rb
+++ b/spec/flagship_spec.rb
@@ -216,5 +216,79 @@ RSpec.describe Flagship do
         expect(flagset.features.disabled.map(&:key)).to eq([:disabled_feature, :conditionally_disabled_feature])
       end
     end
+
+    context 'helper' do
+      let(:flagset) { Flagship.default_flagsets_container.get(:foo) }
+
+      it 'provides a method you can use within procs' do
+        Flagship.define :foo do
+          helper :is_eq do |x, y|
+            x == y
+          end
+
+          enable :bar, if: -> context { is_eq(2, 2) }
+          enable :baz, if: -> context { is_eq(2, 6) }
+        end
+
+        expect(flagset.enabled?(:bar)).to be true
+        expect(flagset.enabled?(:baz)).to be false
+      end
+
+      it 'provides a method you can use for ifs' do
+        Flagship.define :foo do
+          helper(:is_true)  { |context| true }
+          helper(:is_false) { |context| false }
+
+          enable :qux, if: :is_true
+          enable :quz, if: :is_false
+        end
+
+        expect(flagset.enabled?(:qux)).to be true
+        expect(flagset.enabled?(:quz)).to be false
+      end
+
+      it 'is not shared with other flagship declarations' do
+        Flagship.define :foo do
+          helper(:is_true) { |context| true }
+          enable :baz, if: :is_true
+        end
+
+        expect{
+          Flagship.define :bar do
+            enable :baz, if: :is_true
+          end
+        }.to raise_error(NameError)
+      end
+
+      it 'can be defined and included in modules' do
+        module FooMethods
+          def is_foo(context)
+            true
+          end
+        end
+
+        module OtherMethods
+          def is_foo(context)
+            false
+          end
+        end
+
+        Flagship.define :foo do
+          include FooMethods
+          enable :feature, if: :is_foo
+        end
+
+        Flagship.define :bar do
+          include OtherMethods
+          enable :feature, if: :is_foo
+        end
+
+        Flagship.select_flagset(:foo)
+        expect(Flagship.enabled?(:feature)).to be true
+
+        Flagship.select_flagset(:bar)
+        expect(Flagship.enabled?(:feature)).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
From the README...


## Helper methods

You can define helpers with the `helper` keyword. Helpers can be used within blocks, procs, or as symbolic names for if statements to tidy up your code.

```rb
Flagship.define :blog do
  helper :is_author do |comment, user|
    comment.author == user
  end

  def can_view_comment(context)
    context.current_user.moderator?
  end

  enable :comment, if: :can_view_comment
  enable :comment_deletion, if: ->(context) { is_author(context.comment, context.current_user) }
end
```

To share helpers, you can simply include them as modules.


```rb
module FlagHelpers
  def is_author(context)
    context.comment.author == context.current_user
  end
end

Flagship.define :development do
  include FlagHelpers
  enable :delete, if: :is_author
end

Flagship.define :production do
  include FlagHelpers
  enable :delete, if: :is_author
end
```
