### PR TITLE
Extending helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ end
 
 To share helpers, you can simply include them as modules.
 
-
 ```rb
 module FlagHelpers
   def is_author(context)
@@ -183,6 +182,22 @@ end
 
 Flagship.define :production do
   include FlagHelpers
+  enable :delete, if: :is_author
+end
+```
+
+And you can also extend helper methods from base flagset.
+
+```rb
+Flagship.define :base do
+  def staff?(context)
+    def is_author(context)
+      context.comment.author == context.current_user
+    end
+  end
+end
+
+Flagship.define :production do
   enable :delete, if: :is_author
 end
 ```

--- a/README.md
+++ b/README.md
@@ -190,10 +190,8 @@ And you can also extend helper methods from base flagset.
 
 ```rb
 Flagship.define :base do
-  def staff?(context)
-    def is_author(context)
-      context.comment.author == context.current_user
-    end
+  def is_author(context)
+    context.comment.author == context.current_user
   end
 end
 

--- a/lib/flagship/dsl.rb
+++ b/lib/flagship/dsl.rb
@@ -11,9 +11,16 @@ class Flagship::Dsl
     @definition = block
     @base_tags = {}
 
+    if @base
+      @base.helper_methods.each do |method|
+        define_singleton_method(method.name, &method)
+      end
+    end
+
     instance_eval(&@definition)
 
-    @flagset = ::Flagship::Flagset.new(@key, @features, @base)
+    helper_methods = singleton_methods.map { |sym| method(sym) }
+    @flagset = ::Flagship::Flagset.new(@key, @features, @base, helper_methods)
   end
 
   def enable(key, opts = {})

--- a/lib/flagship/flagset.rb
+++ b/lib/flagship/flagset.rb
@@ -1,13 +1,14 @@
 class Flagship::Flagset
-  attr_reader :key
+  attr_reader :key, :helper_methods
 
   class UndefinedFlagError < ::StandardError; end
 
-  def initialize(key, features_hash, base = nil)
+  def initialize(key, features_hash, base = nil, helper_methods = [])
     @key = key
     @features = base ?
       extend_features(features_hash, base) :
       features_hash
+    @helper_methods = helper_methods
   end
 
   def enabled?(key)

--- a/spec/flagship_spec.rb
+++ b/spec/flagship_spec.rb
@@ -297,6 +297,40 @@ RSpec.describe Flagship do
         Flagship.select_flagset(:bar)
         expect(Flagship.enabled?(:feature)).to be false
       end
+
+      it 'can be extended' do
+        Flagship.define :base do
+          def is_foo(context)
+            true
+          end
+        end
+
+        Flagship.define :extending, extend: :base do
+          enable :feature, if: :is_foo
+        end
+
+        Flagship.select_flagset(:extending)
+        expect(Flagship.enabled?(:feature)).to be true
+      end
+
+      it 'can be overridden' do
+        Flagship.define :base do
+          def is_foo(context)
+            true
+          end
+        end
+
+        Flagship.define :extending, extend: :base do
+          def is_foo(context)
+            false
+          end
+
+          enable :feature, if: :is_foo
+        end
+
+        Flagship.select_flagset(:extending)
+        expect(Flagship.enabled?(:feature)).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
@sethjeffery 
I would appreciate if you have any comments about this change.
And now you can merge this if you are happy with it!
I've just invited you to the collaborators of this repo.

---

## From the README.md

And you can also extend helper methods from base flagset.

```rb
Flagship.define :base do
  def staff?(context)
    def is_author(context)
      context.comment.author == context.current_user
    end
  end
end

Flagship.define :production do
  enable :delete, if: :is_author
end
```