### PR TITLE
Postposition helper methods

### DIFF
--- a/lib/flagship/dsl.rb
+++ b/lib/flagship/dsl.rb
@@ -19,7 +19,11 @@ class Flagship::Dsl
   def enable(key, opts = {})
     tags = opts.dup
     condition = tags.delete(:if)
-    condition = method(condition) if condition.is_a?(Symbol) # convert to proc
+    # convert to proc
+    if condition.is_a?(Symbol)
+      sym = condition
+      condition = ->(context) { method(sym).call(context) }
+    end
 
     if condition
       @features[key] = ::Flagship::Feature.new(key, condition, @context, @base_tags.merge(tags))

--- a/spec/flagship_spec.rb
+++ b/spec/flagship_spec.rb
@@ -283,6 +283,8 @@ RSpec.describe Flagship do
           Flagship.define :bar do
             enable :baz, if: :is_true
           end
+          Flagship.select_flagset(:bar)
+          Flagship.enabled?(:baz)
         }.to raise_error(NameError)
       end
 

--- a/spec/flagship_spec.rb
+++ b/spec/flagship_spec.rb
@@ -252,6 +252,24 @@ RSpec.describe Flagship do
         expect(flagset.enabled?(:quz)).to be false
       end
 
+      it 'can be placed after flag definitions' do
+        Flagship.define :foo do
+          enable :qux, if: :is_true
+          enable :quz, if: :is_false
+
+          def is_true(context)
+            true
+          end
+
+          def is_false(context)
+            false
+          end
+        end
+
+        expect(flagset.enabled?(:qux)).to be true
+        expect(flagset.enabled?(:quz)).to be false
+      end
+
       it 'are not shared with other flagship declarations' do
         Flagship.define :foo do
           def is_true(context)


### PR DESCRIPTION
## Problem

Currently, helper methods can't be placed after flag definitions.

```rb
require 'flagship'

Flagship.define :app do
  enable :foo, if: :bar

  def bar(context)
    puts "bar is called"
    true
  end
end

flagset = Flagship.select_flagset(:app)
p flagset.enabled?(:foo)
```

```
$ bundle exec ruby test.rb
/Users/yuya/src/github.com/yuya-takeyama/flagship/lib/flagship/dsl.rb:22:in `method': undefined method `bar' for class `#<Class:#<Flagship::Dsl:0x007ff5fb830060>>' (NameError)
        from /Users/yuya/src/github.com/yuya-takeyama/flagship/lib/flagship/dsl.rb:22:in `enable'
        from test.rb:4:in `block in <main>'
        from /Users/yuya/src/github.com/yuya-takeyama/flagship/lib/flagship/dsl.rb:14:in `instance_eval'
        from /Users/yuya/src/github.com/yuya-takeyama/flagship/lib/flagship/dsl.rb:14:in `initialize'
        from /Users/yuya/src/github.com/yuya-takeyama/flagship/lib/flagship.rb:16:in `new'
        from /Users/yuya/src/github.com/yuya-takeyama/flagship/lib/flagship.rb:16:in `define'
        from test.rb:3:in `<main>'
```

With this change, they can be placed after the flag definitions.

```
$ bundle exec ruby test.rb
bar is called
true
```

---

@sethjeffery 
Please merge if you are happy with it.