### PR TITLE
Allow context to behave more like a hash

### DIFF
--- a/lib/flagship.rb
+++ b/lib/flagship.rb
@@ -22,7 +22,7 @@ module Flagship
 
     def set_context(key_or_hash, value=nil)
       if key_or_hash.is_a?(Hash)
-        default_context.merge!(key_or_hash)
+        key_or_hash.each { |k, v| default_context.__set(k, v) }
       else
         default_context.__set(key_or_hash, value)
       end

--- a/lib/flagship.rb
+++ b/lib/flagship.rb
@@ -20,8 +20,12 @@ module Flagship
       current_flagset.enabled?(key)
     end
 
-    def set_context(key, value)
-      default_context.__set(key, value)
+    def set_context(key_or_hash, value=nil)
+      if key_or_hash.is_a?(Hash)
+        default_context.merge!(key_or_hash)
+      else
+        default_context.__set(key_or_hash, value)
+      end
     end
 
     def select_flagset(key)

--- a/lib/flagship/context.rb
+++ b/lib/flagship/context.rb
@@ -1,6 +1,6 @@
 class Flagship::Context
   extend Forwardable
-  def_delegators :@values, :[], :fetch, :to_h, :clear, :merge!, :update
+  def_delegators :@values, :clear
 
   def initialize
     @values = {}

--- a/lib/flagship/context.rb
+++ b/lib/flagship/context.rb
@@ -1,4 +1,7 @@
 class Flagship::Context
+  extend Forwardable
+  def_delegators :@values, :[], :fetch, :to_h, :clear, :merge!, :update
+
   def initialize
     @values = {}
   end

--- a/spec/flagship_spec.rb
+++ b/spec/flagship_spec.rb
@@ -151,18 +151,6 @@ RSpec.describe Flagship do
     end
   end
 
-  describe '.default_context' do
-    it 'acts like a hash' do
-      Flagship.set_context alpha: 'A', bravo: 'B'
-      expect(Flagship.default_context[:alpha]).to eq 'A'
-      expect(Flagship.default_context[:bravo]).to eq 'B'
-      expect(Flagship.default_context[:charlie]).to be_nil
-
-      Flagship.default_context.clear
-      expect(Flagship.default_context[:alpha]).to be_nil
-    end
-  end
-
   describe '.features' do
     it 'returns Feature objects' do
       Flagship.define :foo do

--- a/spec/flagship_spec.rb
+++ b/spec/flagship_spec.rb
@@ -135,6 +135,32 @@ RSpec.describe Flagship do
       expect(Flagship.enabled?(:bar)).to be true
       expect(Flagship.enabled?(:baz)).to be false
     end
+
+    it 'can set a hash' do
+      Flagship.set_context var: 'VAR', foo: 'BAR'
+
+      Flagship.define :foo do
+        enable :bar, if: ->(context){ context.var == 'VAR' }
+        enable :baz, if: ->(context){ context.foo == 'BAR' }
+      end
+
+      Flagship.select_flagset(:foo)
+
+      expect(Flagship.enabled?(:bar)).to be true
+      expect(Flagship.enabled?(:baz)).to be true
+    end
+  end
+
+  describe '.default_context' do
+    it 'acts like a hash' do
+      Flagship.set_context alpha: 'A', bravo: 'B'
+      expect(Flagship.default_context[:alpha]).to eq 'A'
+      expect(Flagship.default_context[:bravo]).to eq 'B'
+      expect(Flagship.default_context[:charlie]).to be_nil
+
+      Flagship.default_context.clear
+      expect(Flagship.default_context[:alpha]).to be_nil
+    end
   end
 
   describe '.features' do


### PR DESCRIPTION
@yuya-takeyama 

This allows contexts to be a bit more hash-like.

I found a need to be able to do the following:

- Grab a context value that *might not exist* without raising an exception:
  - `Flagship.default_context[:my_value]`

- Clear all context values after each test:
  - `Flagship.default_context.clear`

- Set multiple context values in one statement (merge):
  - `Flagship.set_context({ foo: 'bar', baz: 'quz' })`
  - `Flagship.default_context.merge!({ foo: 'bar', baz: 'quz' })`
