### PR TITLE
Flagship.with_context

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ Or you can set a method too.
 Flagship.set_context :current_user, method(:current_user)
 ```
 
+### Apply temporal changes to context variables
+
+Using `Flagship.with_context` method, you can override context variables temporarily.
+
+```rb
+class User
+  def enabled_features
+    Flagship.with_context current_user: self do
+      Flagship.features.enabled.map(&:key)
+    end
+  end
+end
+```
+
+It's useful when you implement a method using `Flagship` into some domain objects.
+
+By using this, values specified in the argument is overridden and other values are inherited.
+
 ### Extend flagset
 
 ```rb

--- a/lib/flagship.rb
+++ b/lib/flagship.rb
@@ -28,6 +28,12 @@ module Flagship
       end
     end
 
+    def with_context(values, &block)
+      default_context.with_values values do
+        block.call
+      end
+    end
+
     def select_flagset(key)
       @current_flagset = default_flagsets_container.get(key)
     end

--- a/lib/flagship/context.rb
+++ b/lib/flagship/context.rb
@@ -27,4 +27,12 @@ class Flagship::Context
   def respond_to_missing?(name, include_private = false)
     @values.key?(name) or super
   end
+
+  def with_values(values, &block)
+    original_values = @values
+    @values = @values.dup.merge(values)
+    block.call
+  ensure
+    @values = original_values
+  end
 end


### PR DESCRIPTION
Using `Flagship.with_context` method, you can override context variables temporarily.

```rb
class User
  def enabled_features
    Flagship.with_context current_user: self do
      Flagship.features.enabled.map(&:key)
    end
  end
end
```

It's useful when you implement a method using `Flagship` into some domain objects.

By using this, values specified in the argument is overridden and other values are inherited.