### PR TITLE
Clear context variables as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,26 @@ Flagship.define :production do
 end
 ```
 
+### Testing
+
+#### RSpec
+
+It's recommended to clear state of `Flagship` before the suite and after the each tests.
+
+You can do it by configuring like below:
+
+```rb
+RSpec.configure do |config|
+  config.before(:suite) do
+    Flagship.clear_state
+  end
+
+  config.after(:each) do
+    Flagship.clear_state
+  end
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/flagship.rb
+++ b/lib/flagship.rb
@@ -61,6 +61,7 @@ module Flagship
     def clear_state
       @default_flagsts_container = nil
       @current_flagset = nil
+      @default_context = nil
     end
   end
 end

--- a/spec/flagship_spec.rb
+++ b/spec/flagship_spec.rb
@@ -1,8 +1,4 @@
 RSpec.describe Flagship do
-  before do
-    Flagship.clear_state
-  end
-
   describe '.define' do
     it 'defines a flagset' do
       Flagship.define(:foo) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,11 @@
 require 'flagship'
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    Flagship.clear_state
+  end
+
+  config.after(:each) do
+    Flagship.clear_state
+  end
+end


### PR DESCRIPTION
And wrote usage with RSpec.

---

### Testing

#### RSpec

It's recommended to clear state of `Flagship` before the suite and after the each tests.

You can do it by configuring like below:

```rb
RSpec.configure do |config|
  config.before(:suite) do
    Flagship.clear_state
  end

  config.after(:each) do
    Flagship.clear_state
  end
end
```