### PR TITLE
Separate method to clear state

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,11 +229,13 @@ You can do it by configuring like below:
 ```rb
 RSpec.configure do |config|
   config.before(:suite) do
-    Flagship.clear_state
+    Flagship.clear_context
+    Flagship.clear_current_flagset
   end
 
   config.after(:each) do
-    Flagship.clear_state
+    Flagship.clear_context
+    Flagship.clear_current_flagset
   end
 end
 ```

--- a/lib/flagship.rb
+++ b/lib/flagship.rb
@@ -59,8 +59,20 @@ module Flagship
     end
 
     def clear_state
+      clear_flagsets_container
+      clear_current_flagset
+      clear_context
+    end
+
+    def clear_flagsets_container
       @default_flagsts_container = nil
+    end
+
+    def clear_current_flagset
       @current_flagset = nil
+    end
+
+    def clear_context
       @default_context && @default_context.clear
     end
   end


### PR DESCRIPTION
Regarding apps using `Flagship`, clearing flagsets in unit-tests does not make sense.
It requires redefinition of flagsets.