### PR TITLE
Make context thread safe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,3 @@ rvm:
   - 2.5.8
   - 2.6.6
   - 2.7.1
-
-before_install: gem install bundler --no-document

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: ruby
 
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.10
+  - 2.3.8
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 
 before_install: gem install bundler --no-document

--- a/flagship.gemspec
+++ b/flagship.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler", "> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.5.0"
 end

--- a/lib/flagship/context.rb
+++ b/lib/flagship/context.rb
@@ -2,19 +2,15 @@ require 'forwardable'
 
 class Flagship::Context
   extend Forwardable
-  def_delegators :@values, :clear
-
-  def initialize
-    @values = {}
-  end
+  def_delegators :current_values, :clear
 
   def __set(key, value)
-    @values[key.to_sym] = value
+    current_values[key.to_sym] = value
   end
 
   def method_missing(name, args = [], &block)
-    if @values.key?(name)
-      value = @values[name]
+    if current_values.key?(name)
+      value = current_values[name]
 
       if value.respond_to?(:call)
         value.call
@@ -27,14 +23,24 @@ class Flagship::Context
   end
 
   def respond_to_missing?(name, include_private = false)
-    @values.key?(name) or super
+    current_values.key?(name) or super
   end
 
-  def with_values(values, &block)
-    original_values = @values
-    @values = @values.dup.merge(values)
+  def with_values(new_values, &block)
+    original_values = current_values
+    self.current_values = current_values.dup.merge(new_values)
     block.call
   ensure
-    @values = original_values
+    self.current_values = original_values
+  end
+
+  private
+
+  def current_values
+    Thread.current[:__flagship_context_values] ||= {}
+  end
+
+  def current_values=(new_values)
+    Thread.current[:__flagship_context_values] = new_values
   end
 end

--- a/lib/flagship/context.rb
+++ b/lib/flagship/context.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 class Flagship::Context
   extend Forwardable
   def_delegators :@values, :clear


### PR DESCRIPTION
This PR depends on https://github.com/yuya-takeyama/flagship/pull/33

------

Thank you for creating this great gem.

If we use puma as a web server, thread-safe context is important.
I think current implementation isn't thread-safe so let me make it thread safe.

Honestly, I'd like to replace passing `@context` instance variable with a class method like `Flagship.current_context` because I think we shouldn't share `Flagship::Context` instance across threads.

What do you think?